### PR TITLE
Delete the CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.aiclub.osu.edu


### PR DESCRIPTION
Until you have the OSU domain redirected to here, I would suggest leaving this alone so that users can still access the website.

Use `git revert a71e694ca513067ce1f93672a94abdc090a97f1c` to undo this change once the domain is pointed to this website.